### PR TITLE
Install 100Change2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ The `.env.template` file explains the circumstances in which a developer may wan
 
 5. Run `vagrant up`
 
-This will build the machine and run the configuration. The machine will not have any competitions set up yet; this will need to be done manually depending on which competition you want to work with.
+This will build the machine and run the configuration. The final output will expose what the IP address of your guest machine is. This is dynamic and frequently changes between restarts.
+
+The following competitions are enabled after provisioning:
+
+* DemoView (accessed at `http://{GUEST_IP}/DemoView`)
+* 100Change2020 (accessed at `http://{GUEST_IP}/100Change2020`)
 
 ## Tips
 

--- a/configure.sh
+++ b/configure.sh
@@ -24,6 +24,9 @@ chown -R www-data /var/www/
 echo "Set up base ansible"
 export ANSIBLE_ROLES_PATH=$ANSIBLE_ROLES_PATH:/home/vagrant/torque-sites/roles
 
+# Configure apache
+cp $TEMPLATES_PATH/etc/apache2/apache2.conf /etc/apache2/apache2.conf
+
 # Configure subversion
 mkdir /root/.subversion
 cp -R $TEMPLATES_PATH/root/.subversion/* /root/.subversion

--- a/configure.sh
+++ b/configure.sh
@@ -114,4 +114,20 @@ cd /home/vagrant/torque-sites/competitions/DemoView/ansible
 envsubst < inv/local/group_vars/all.tmpl > inv/local/group_vars/all
 ansible-playbook DemoView.yml -i inv/local
 
+# Install the 100Change2020 competition
+echo "INSTALL 100Change2020 competition"
+export MEDIAWIKI_INSTALL_DIRECTORY=/var/www/html/competitions/100Change2020
+cd /home/vagrant/torque-sites/competitions/100Change2020/ansible
+envsubst < inv/local/group_vars/all.tmpl > inv/local/group_vars/all
+ansible-playbook 100Change2020.yml -i inv/local
+if [ ETL_ENABLED ]
+then
+	export WIKI_URL='http://127.0.0.1/100Change2020'
+	cd $OTS_DIR/clients/lever-for-change/torque-sites/100Change2020/data
+	$OTS_DIR/utils/get-bigdata -c
+	cd /home/vagrant/torque-sites/competitions/100Change2020/etl
+	envsubst < config.py.tmpl > config.py
+	./deploy -g "$DECRYPTION_PASSPHRASE" /home/vagrant/data/decrypted
+fi
+
 echo "ALL DONE"


### PR DESCRIPTION
This adds out of the box support for the 100Change2020 competition.

We may decide to separate the competitions into their own provision scripts eventually, allowing developers to decide which competitions to install.  Until then, we'll just have them all included by default.