### PR TITLE
Improve SimpleBook supervisor config

### DIFF
--- a/templates/etc/supervisor/conf.d/simplebook.conf
+++ b/templates/etc/supervisor/conf.d/simplebook.conf
@@ -1,4 +1,4 @@
-[program:simplebook]
+[program:simplebookserver]
 directory=/home/vagrant/SimpleBook/services/api
 user:vagrant
 command=pipenv run gunicorn --reload --bind 0.0.0.0:3333 wsgi:app
@@ -19,3 +19,6 @@ stdout_logfile = /var/log/simplebookworker.output.log
 autorestart=true
 redirect_stderr=true
 redirect_stdout=true
+
+[group:simplebook]
+programs=simplebookserver,simplebookworker


### PR DESCRIPTION
This PR adds a small fix to the SimpleBook supervisor config.

This config is still not fully correct, as it has a bug where simplebook needs to bemanually started after `vagrant up` by typing `sudo supervisorctl update simplebook`.

However, this makes it *more* correct in that it now at least loads both the server and worker aspects of simplebook.