### PR TITLE
Install SimpleBook via Ansible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .vagrant
-.env
+configuration.env
 *.log

--- a/configure.sh
+++ b/configure.sh
@@ -57,11 +57,6 @@ echo "Install essential software pacakges"
 apt-get -qq update
 apt-get -qq install -y ansible
 
-echo "Install Node"
-curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -
-sudo apt -y install nodejs
-sudo npm install --global yarn
-
 echo "Install ETL software packages"
 apt-get -qq install -y subversion git gpg unzip python3-pip acl
 apt-get -qq install -y xlsx2csv
@@ -70,19 +65,6 @@ echo "Install web server tools"
 apt-get -qq install -y apache2
 chown -R www-data /var/www/
 
-echo "Install SimpleBook depdendencies"
-apt-get -qq install -y ca-certificates fonts-liberation libappindicator3-1 libasound2
-apt-get -qq install -y libatk-bridge2.0-0 libatk1.0-0 libc6libcairo2 libcups2 libdbus-1-3
-apt-get -qq install -y libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4
-apt-get -qq install -y libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1
-apt-get -qq install -y libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6
-apt-get -qq install -y libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils
-apt-get -qq install -y pipenv
-npm install -g yarn
-cd /home/vagrant/SimpleBook/services/api/mw2pdf
-yarn install
-cd /home/vagrant/SimpleBook/services/api
-pipenv install
 
 echo "Set up Redis"
 cd /home/vagrant
@@ -120,7 +102,8 @@ export MEDIAWIKI_MWLIB_USERNAME=mwlib
 export MEDIAWIKI_MWLIB_PASSWORD=mwlib_password
 export MEDIAWIKI_CSV2WIKI_USERNAME=csv2wiki
 export MEDIAWIKI_CSV2WIKI_PASSWORD=csv2wiki_password
-export MWLIB_INSTALL_DIRECTORY=/home/vagrant/mwlib/
+export MWLIB_INSTALL_DIRECTORY=/home/vagrant/installed_services/mwlib/
+export SIMPLEBOOK_INSTALL_DIRECTORY=/home/vagrant/installed_services/simplebook # this MUST NOT END IN A SLASH
 export MYSQL_ROOT_PASSWORD=root
 export ROOT_WEB_DIRECTORY=/var/www/html
 export SIMPLESAML_INSTALL_DIRECTORY=/home/vagrant/simplesaml
@@ -189,11 +172,6 @@ else
 	ETL_ENABLED=true
 fi
 
-# Set up SimpleBook
-cp $TEMPLATES_PATH/etc/supervisor/conf.d/simplebook.conf /etc/supervisor/conf.d/simplebook.conf
-sudo supervisorctl update simplebook
-sudo supervisorctl update simplebook-api
-
 # Install the DemoView competition
 echo "INSTALL DemoView competition"
 export MEDIAWIKI_INSTALL_DIRECTORY=/var/www/html/competitions/DemoView
@@ -215,8 +193,6 @@ then
 	cd /home/vagrant/torque-sites/competitions/100Change2020/etl
 	envsubst < config.py.tmpl > config.py
 	./deploy -g "$DECRYPTION_PASSPHRASE" /home/vagrant/data/decrypted
-	rm -fr /var/www/html/100Change2020/extensions/Collection
-	ln -s /home/vagrant/SimpleBook /var/www/html/100Change2020/extensions/Collection
 fi
 
 # Install the LLIIA2020 competition
@@ -233,11 +209,9 @@ then
 	cd /home/vagrant/torque-sites/competitions/LLIIA2020/etl
 	envsubst < config.py.tmpl > config.py
 	./deploy -g "$DECRYPTION_PASSPHRASE" /home/vagrant/data/decrypted
-	rm -fr /var/www/html/LLIIA2020/extensions/Collection
-	ln -s /home/vagrant/SimpleBook /var/www/html/LLIIA2020/extensions/Collection
 fi
 
-# Install the Climte2030 competition
+# Install the Climate2030 competition
 echo "INSTALL Climate2030 competition"
 export MEDIAWIKI_INSTALL_DIRECTORY=/var/www/html/competitions/Climate2030
 cd /home/vagrant/torque-sites/competitions/Climate2030/ansible
@@ -251,8 +225,6 @@ then
 	cd /home/vagrant/torque-sites/competitions/Climate2030/etl
 	envsubst < config.py.tmpl > config.py
 	./deploy -g "$DECRYPTION_PASSPHRASE" /home/vagrant/data/decrypted
-	rm -fr /var/www/html/Climate2030/extensions/Collection
-	ln -s /home/vagrant/SimpleBook /var/www/html/Climate2030/extensions/Collection
 fi
 
 # Install the LoneStar2020 competition
@@ -269,8 +241,6 @@ then
 	cd /home/vagrant/torque-sites/competitions/LoneStar2020/etl
 	envsubst < config.py.tmpl > config.py
 	./deploy -g "$DECRYPTION_PASSPHRASE" /home/vagrant/data/decrypted
-	rm -fr /var/www/html/LoneStar2020/extensions/Collection
-	ln -s /home/vagrant/SimpleBook /var/www/html/LoneStar2020/extensions/Collection
 fi
 
 echo "ALL DONE"


### PR DESCRIPTION
This PR updates our development environment to use the Ansible Scripts when installing and configuring SimpleBook.  It also replaces the actual code base of the ansible-installed SimpleBook with our mounted copy so that we can actually develop the project in our development environment.

In order to test this you will need to:

1. have this branch checked out in your copy of `torque-sites`: https://github.com/OpenTechStrategies/torque-sites/tree/10-add-simplebook-ansible

2. `vagrant destroy` & `vagrant up`

3. `vagrant ssh`

4. `sudo supervisorctl status` and should see the two simplebook services running.

Note that SimpleBook is not actually installed in any of the sites at that point (see https://github.com/OpenTechStrategies/torque-sites/pull/114 for instructions on how to locally install SimpleBook in a given competition)

Resolves #20 
Resolves #22 illegally and I should probably put that in its own PR.