### PR TITLE
Fix SVN credential caching

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -77,7 +77,12 @@ cp $TEMPLATES_PATH/etc/apache2/apache2.conf /etc/apache2/apache2.conf
 
 # Configure subversion
 mkdir /root/.subversion
+export OTS_SVN_PASSWORD_LENGTH=${#OTS_SVN_PASSWORD}
+export OTS_SVN_USERNAME_LENGTH=${#OTS_SVN_USERNAME}
 cp -R $TEMPLATES_PATH/root/.subversion/* /root/.subversion
+# SVN recently disabled non-interactive credential caching so we need to manually populate the cache
+envsubst < /root/.subversion/auth/svn.simple/f3f481873e9051b96cd12601a28ac010.tmpl > /root/.subversion/auth/svn.simple/f3f481873e9051b96cd12601a28ac010
+rm /root/.subversion/auth/svn.simple/f3f481873e9051b96cd12601a28ac010.tmpl
 
 # Define env variables for ansible templates
 export DB_USERNAME=torque

--- a/templates/root/.subversion/auth/svn.simple/f3f481873e9051b96cd12601a28ac010.tmpl
+++ b/templates/root/.subversion/auth/svn.simple/f3f481873e9051b96cd12601a28ac010.tmpl
@@ -1,0 +1,17 @@
+K 8
+passtype
+V 6
+simple
+K 15
+svn:realmstring
+V 66
+<https://svn.opentechstrategies.com:443> Open Tech Strategies, LLC
+K 8
+username
+V ${OTS_SVN_USERNAME_LENGTH}
+${OTS_SVN_USERNAME}
+K 8
+password
+V ${OTS_SVN_PASSWORD_LENGTH}
+${OTS_SVN_PASSWORD}
+END

--- a/templates/root/.subversion/config
+++ b/templates/root/.subversion/config
@@ -12,8 +12,8 @@
 
 ### Section for authentication and authorization customizations.
 [auth]
-### We need to explicitly disable password stores in order to have passwords save properly
-### on the guest machine.
+### We need to explicitly set the password stores to empty in order to have
+### passwords save properly on the guest machine.
 password-stores =
 
 ### We don't use any of these sections.


### PR DESCRIPTION
This PR creates an SVN credential cache file, since SVN doesn't want to do that kind of thing any more.

Resolves #31 